### PR TITLE
Remove NPM and Gulp states

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -6,7 +6,6 @@ base:
         - elife.nginx
         - elife.nginx-php7
         - elife.redis-server
-        - elife.nodejs6
         - personalised-covers.aws
         - personalised-covers
         - api-dummy

--- a/salt/personalised-covers/init.sls
+++ b/salt/personalised-covers/init.sls
@@ -100,23 +100,6 @@ personalised-covers-composer-install:
             - personalised-covers-logs
             - personalised-covers-data
 
-personalised-covers-npm-install:
-    cmd.run:
-        - name: npm install
-        - cwd: /srv/personalised-covers
-        - user: {{ pillar.elife.deploy_user.username }}
-        - require:
-            - personalised-covers-repository
-
-personalised-covers-gulp:
-    cmd.run:
-        - name: node_modules/.bin/gulp
-        - cwd: /srv/personalised-covers
-        - user: {{ pillar.elife.deploy_user.username }}
-        - require:
-            - personalised-covers-npm-install
-            - personalised-covers-composer-install
-
 personalised-covers-console-ready:
     cmd.run:
         - name: ./bin/console --env={{ pillar.elife.env }}


### PR DESCRIPTION
As mentioned here, the pattern library assets are linked using a simple symlink, so no need to invoke NPM or Gulp: https://github.com/elifesciences/personalised-covers/pull/32/commits/f4b471896ce6cfd453b0bfeef247118a4f4e1f2c