### PR TITLE
Add state to generate font files at build time

### DIFF
--- a/salt/personalised-covers/init.sls
+++ b/salt/personalised-covers/init.sls
@@ -100,6 +100,14 @@ personalised-covers-composer-install:
             - personalised-covers-logs
             - personalised-covers-data
 
+personalised-covers-gen-fonts:
+    cmd.run:
+        - name: ./bin/font-generator
+        - user: {{ pillar.elife.deploy_user.username }}
+        - cwd: /srv/personalised-covers
+        - require:
+            - personalised-covers-composer-install
+
 personalised-covers-console-ready:
     cmd.run:
         - name: ./bin/console --env={{ pillar.elife.env }}


### PR DESCRIPTION
Fixes missing font files.  Will generate the required TCPDF files from the TrueType Fonts using the the included font-generator script.