### PR TITLE
landing_page_url and landing_page are not used.

### DIFF
--- a/salt/personalised-covers/config/srv-personalised-covers-config-config.php
+++ b/salt/personalised-covers/config/srv-personalised-covers-config-config.php
@@ -15,7 +15,6 @@ return [
 	'aws_bucket' => "{{ pillar.personalised_covers.aws.bucket }}",
 	'elife_api' => "{{ pillar.personalised_covers.api }}",
 	'journal_url' => "{{ pillar.personalised_covers.journal_url }}",
-	'landing_page_url' => "{{ pillar.personalised_covers.landing_page }}",
 	'font_path' => '/srv/personalised-covers/data/fonts/output',
 	'cover_images' => [
 		'load_paths' => [

--- a/salt/pillar/personalised-covers.sls
+++ b/salt/pillar/personalised-covers.sls
@@ -2,7 +2,6 @@ personalised_covers:
     gtm_id: GTM-XXXX
     api: 'http://localhost:8080/'
     journal_url: 'https://continuumtest--journal.elifesciences.org/'
-    landing_page: 'http://elifesciences.org/cover/%s'
     aws:
         access_key_id: null
         secret_access_key: null


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5798

The `landing_page_url` value is not used by the project, and subsequently means `landing_page` can also be removed.

I'll be removing it from the `personalised-covers` project too.

Since it is never used in the code itself, it should be safe to merge this PR and the other without any breakage.